### PR TITLE
Optimize GetSqrtRatioAtTick and GetTickAtSqrtRatio

### DIFF
--- a/utils/tick_math.go
+++ b/utils/tick_math.go
@@ -24,13 +24,34 @@ var (
 	ErrInvalidSqrtRatio = errors.New("invalid sqrt ratio")
 )
 
-func mulShift(val *big.Int, mulBy string) *big.Int {
-	mulByBig, ok := new(big.Int).SetString(mulBy[2:], 16)
-	if !ok {
-		panic("invalid mulBy")
-	}
-	return new(big.Int).Rsh(new(big.Int).Mul(val, mulByBig), 128)
+func mulShift(val *big.Int, mulBy *big.Int) *big.Int {
+
+	return new(big.Int).Rsh(new(big.Int).Mul(val, mulBy), 128)
 }
+
+var (
+	sqrtConst1, _  = new(big.Int).SetString("fffcb933bd6fad37aa2d162d1a594001", 16)
+	sqrtConst2, _  = new(big.Int).SetString("100000000000000000000000000000000", 16)
+	sqrtConst3, _  = new(big.Int).SetString("fff97272373d413259a46990580e213a", 16)
+	sqrtConst4, _  = new(big.Int).SetString("fff2e50f5f656932ef12357cf3c7fdcc", 16)
+	sqrtConst5, _  = new(big.Int).SetString("ffe5caca7e10e4e61c3624eaa0941cd0", 16)
+	sqrtConst6, _  = new(big.Int).SetString("ffcb9843d60f6159c9db58835c926644", 16)
+	sqrtConst7, _  = new(big.Int).SetString("ff973b41fa98c081472e6896dfb254c0", 16)
+	sqrtConst8, _  = new(big.Int).SetString("ff2ea16466c96a3843ec78b326b52861", 16)
+	sqrtConst9, _  = new(big.Int).SetString("fe5dee046a99a2a811c461f1969c3053", 16)
+	sqrtConst10, _ = new(big.Int).SetString("fcbe86c7900a88aedcffc83b479aa3a4", 16)
+	sqrtConst11, _ = new(big.Int).SetString("f987a7253ac413176f2b074cf7815e54", 16)
+	sqrtConst12, _ = new(big.Int).SetString("f3392b0822b70005940c7a398e4b70f3", 16)
+	sqrtConst13, _ = new(big.Int).SetString("e7159475a2c29b7443b29c7fa6e889d9", 16)
+	sqrtConst14, _ = new(big.Int).SetString("d097f3bdfd2022b8845ad8f792aa5825", 16)
+	sqrtConst15, _ = new(big.Int).SetString("a9f746462d870fdf8a65dc1f90e061e5", 16)
+	sqrtConst16, _ = new(big.Int).SetString("70d869a156d2a1b890bb3df62baf32f7", 16)
+	sqrtConst17, _ = new(big.Int).SetString("31be135f97d08fd981231505542fcfa6", 16)
+	sqrtConst18, _ = new(big.Int).SetString("9aa508b5b7a84e1c677de54f3e99bc9", 16)
+	sqrtConst19, _ = new(big.Int).SetString("5d6af8dedb81196699c329225ee604", 16)
+	sqrtConst20, _ = new(big.Int).SetString("2216e584f5fa1ea926041bedfe98", 16)
+	sqrtConst21, _ = new(big.Int).SetString("48a170391f7dc42444e8fa2", 16)
+)
 
 /**
  * Returns the sqrt ratio as a Q64.96 for the given tick. The sqrt ratio is computed as sqrt(1.0001)^tick
@@ -46,66 +67,66 @@ func GetSqrtRatioAtTick(tick int) (*big.Int, error) {
 	}
 	var ratio *big.Int
 	if absTick&0x1 != 0 {
-		ratio, _ = new(big.Int).SetString("fffcb933bd6fad37aa2d162d1a594001", 16)
+		ratio = sqrtConst1
 	} else {
-		ratio, _ = new(big.Int).SetString("100000000000000000000000000000000", 16)
+		ratio = sqrtConst2
 	}
 	if (absTick & 0x2) != 0 {
-		ratio = mulShift(ratio, "0xfff97272373d413259a46990580e213a")
+		ratio = mulShift(ratio, sqrtConst3)
 	}
 	if (absTick & 0x4) != 0 {
-		ratio = mulShift(ratio, "0xfff2e50f5f656932ef12357cf3c7fdcc")
+		ratio = mulShift(ratio, sqrtConst4)
 	}
 	if (absTick & 0x8) != 0 {
-		ratio = mulShift(ratio, "0xffe5caca7e10e4e61c3624eaa0941cd0")
+		ratio = mulShift(ratio, sqrtConst5)
 	}
 	if (absTick & 0x10) != 0 {
-		ratio = mulShift(ratio, "0xffcb9843d60f6159c9db58835c926644")
+		ratio = mulShift(ratio, sqrtConst6)
 	}
 	if (absTick & 0x20) != 0 {
-		ratio = mulShift(ratio, "0xff973b41fa98c081472e6896dfb254c0")
+		ratio = mulShift(ratio, sqrtConst7)
 	}
 	if (absTick & 0x40) != 0 {
-		ratio = mulShift(ratio, "0xff2ea16466c96a3843ec78b326b52861")
+		ratio = mulShift(ratio, sqrtConst8)
 	}
 	if (absTick & 0x80) != 0 {
-		ratio = mulShift(ratio, "0xfe5dee046a99a2a811c461f1969c3053")
+		ratio = mulShift(ratio, sqrtConst9)
 	}
 	if (absTick & 0x100) != 0 {
-		ratio = mulShift(ratio, "0xfcbe86c7900a88aedcffc83b479aa3a4")
+		ratio = mulShift(ratio, sqrtConst10)
 	}
 	if (absTick & 0x200) != 0 {
-		ratio = mulShift(ratio, "0xf987a7253ac413176f2b074cf7815e54")
+		ratio = mulShift(ratio, sqrtConst11)
 	}
 	if (absTick & 0x400) != 0 {
-		ratio = mulShift(ratio, "0xf3392b0822b70005940c7a398e4b70f3")
+		ratio = mulShift(ratio, sqrtConst12)
 	}
 	if (absTick & 0x800) != 0 {
-		ratio = mulShift(ratio, "0xe7159475a2c29b7443b29c7fa6e889d9")
+		ratio = mulShift(ratio, sqrtConst13)
 	}
 	if (absTick & 0x1000) != 0 {
-		ratio = mulShift(ratio, "0xd097f3bdfd2022b8845ad8f792aa5825")
+		ratio = mulShift(ratio, sqrtConst14)
 	}
 	if (absTick & 0x2000) != 0 {
-		ratio = mulShift(ratio, "0xa9f746462d870fdf8a65dc1f90e061e5")
+		ratio = mulShift(ratio, sqrtConst15)
 	}
 	if (absTick & 0x4000) != 0 {
-		ratio = mulShift(ratio, "0x70d869a156d2a1b890bb3df62baf32f7")
+		ratio = mulShift(ratio, sqrtConst16)
 	}
 	if (absTick & 0x8000) != 0 {
-		ratio = mulShift(ratio, "0x31be135f97d08fd981231505542fcfa6")
+		ratio = mulShift(ratio, sqrtConst17)
 	}
 	if (absTick & 0x10000) != 0 {
-		ratio = mulShift(ratio, "0x9aa508b5b7a84e1c677de54f3e99bc9")
+		ratio = mulShift(ratio, sqrtConst18)
 	}
 	if (absTick & 0x20000) != 0 {
-		ratio = mulShift(ratio, "0x5d6af8dedb81196699c329225ee604")
+		ratio = mulShift(ratio, sqrtConst19)
 	}
 	if (absTick & 0x40000) != 0 {
-		ratio = mulShift(ratio, "0x2216e584f5fa1ea926041bedfe98")
+		ratio = mulShift(ratio, sqrtConst20)
 	}
 	if (absTick & 0x80000) != 0 {
-		ratio = mulShift(ratio, "0x48a170391f7dc42444e8fa2")
+		ratio = mulShift(ratio, sqrtConst21)
 	}
 	if tick > 0 {
 		ratio = new(big.Int).Div(entities.MaxUint256, ratio)
@@ -118,6 +139,12 @@ func GetSqrtRatioAtTick(tick int) (*big.Int, error) {
 		return new(big.Int).Div(ratio, Q32), nil
 	}
 }
+
+var (
+	magicSqrt10001, _ = new(big.Int).SetString("255738958999603826347141", 10)
+	magicTickLow, _   = new(big.Int).SetString("3402992956809132418596140100660247210", 10)
+	magicTickHigh, _  = new(big.Int).SetString("291339464771989622907027621153398088495", 10)
+)
 
 /**
  * Returns the tick corresponding to a given sqrt ratio, s.t. #getSqrtRatioAtTick(tick) <= sqrtRatioX96
@@ -149,12 +176,9 @@ func GetTickAtSqrtRatio(sqrtRatioX96 *big.Int) (int, error) {
 		r = new(big.Int).Rsh(r, uint(f.Int64()))
 	}
 
-	magicSqrt10001, _ := new(big.Int).SetString("255738958999603826347141", 10)
 	logSqrt10001 := new(big.Int).Mul(log2, magicSqrt10001)
 
-	magicTickLow, _ := new(big.Int).SetString("3402992956809132418596140100660247210", 10)
 	tickLow := new(big.Int).Rsh(new(big.Int).Sub(logSqrt10001, magicTickLow), 128).Int64()
-	magicTickHigh, _ := new(big.Int).SetString("291339464771989622907027621153398088495", 10)
 	tickHigh := new(big.Int).Rsh(new(big.Int).Add(logSqrt10001, magicTickHigh), 128).Int64()
 
 	if tickLow == tickHigh {


### PR DESCRIPTION
Move the constants outside of the functions so we don't have to do a lot of string parsing in order to perform the calculation. 